### PR TITLE
docker composeを最新のローカルイメージで起動できるように環境変数等を設定した

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -25,9 +25,18 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION}}
       - name: authorize docker to push to ECR
-        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION}}  | docker login --username AWS --password-stdin ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.${{secrets.AWS_REGION}}.amazonaws.com
+        run: aws ecr get-login-password --region $aws-region | docker login --username AWS --password-stdin ${{secrets.AWS_ACCOUNT_ID}}.dkr.ecr.$aws-region.amazonaws.com
+      # docker imageをbuild
+      # secretsの情報をbuild時に渡す
       - name: build docker image
-        run: docker build -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION}}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest .
+        env:
+          MYSQL_DATABASE: ${{ secrets.DB_NAME }}
+          MYSQL_USER: ${{ secrets.DB_USER }}
+          MYSQL_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          DB_ENDPOINT: ${{ secrets.DB_ENDPOINT }}
+          SEVER_PORT: 8030
+          ENV: "release"
+        run: docker image build --build-arg MYSQL_DATABASE=$MYSQL_DATABASE --build-arg MYSQL_USER=$MYSQL_USER --build-arg MYSQL_PASSWORD=$MYSQL_PASSWORD --build-arg DB_ENDPOINT=$DB_ENDPOINT --build-arg ENV=release --build-arg SEVER_PORT=$SEVER_PORT -t ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$aws-region.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest .
+      # docker imageをECRにpush
       - name: push docker image
-        run: docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION}}.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest
-
+        run: docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.$aws-region.amazonaws.com/${{ secrets.ECR_REPOSITORY_NAME }}:latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .env
+.env.*
 go.work
+
+*.sh

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  "editor.minimap.enabled": false, // ミニマップを非表示にする
+  "editor.renderControlCharacters": true, // 制御文字を表示する
+  "editor.suggestSelection": "first", // サジェスト一覧の初期表示項目設定
+  "breadcrumbs.enabled": true, // ファイルのパンくずリストを表示する
+  "files.insertFinalNewline": true, // ファイルの末尾を改行で終わらせる
+  "editor.fontFamily": "'Fira Code', Hasklig, Consolas, 'Courier New', monospace",
+  "editor.fontLigatures": true, // 合字を有効化
+  "editor.fontSize": 17, // フォントサイズを変更
+  "editor.tabSize": 2, // タブ幅を2に
+  "editor.renderLineHighlight": "all", // 選択行の行番号をハイライトする
+  "editor.cursorBlinking": "smooth", // カーソルが滑らかに点滅するように
+  "editor.cursorSmoothCaretAnimation": "on", // カーソルの点滅をアニメーション表示する
+  "editor.cursorStyle": "block", // カーソルの外観をブロックに変更
+  "files.autoSave": "onFocusChange", // ファイルのフォーカスが変わった際に自動保存を実施
+  "window.zoomLevel": 0, // 画面全体の表示サイズはデフォルト
+  "editor.bracketPairColorization.enabled": true // 括弧の対応を色付ける
+}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,13 @@
 version: "3.9"
 services:
   web:
-    build: .
+    build: 
+      context: .
+      args:
+        ENV: debug
+        SERVER_PORT: 8030
     ports:
       - "8000:8030"
-    environment:
-      PORT: 8030
-      env: debug
     depends_on:
       - db
   db:

--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,25 @@
 FROM golang:1.20.0-buster AS builder
 
+ARG SERVER_PORT
+ARG DB_ENDPOINT
+ARG MYSQL_USER
+ARG MYSQL_PASSWORD
+ARG MYSQL_DATABASE
+ARG ENV
+
+ENV SERVER_PORT=${SERVER_PORT}
+ENV DB_ENDPOINT=${DB_ENDPOINT}
+ENV MYSQL_USER=${MYSQL_USER}
+ENV MYSQL_PASSWORD=${MYSQL_PASSWORD}
+ENV MYSQL_DATABASE=${MYSQL_DATABASE}
+ENV ENV=${ENV}
+
 WORKDIR /usr/src/app
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
 COPY main.go ./
+COPY schema.go ./
 RUN go build -v -o /usr/bin/app
 
 CMD [ "/usr/bin/app" ]

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,11 @@ aws aurora
 
 ## 開発環境
 
-`docker compose build`
+dockerイメージを作成する時のコマンド
+`docker image build --build-arg MYSQL_DATABASE=$MYSQL_DATABASE MYSQL_USER=$MYSQL_USER　DB_PASSWORD=$DB_PASSWORD　DB_ENDPOINT=$DB_ENDPOINT　ENV=$ENV -t local-test:latest .`
+
+docker composeのサービスを作成する時のコマンド
+`docker compose build --build-arg　ENV=$ENV SERVER_PORT=$SERVER_PORT web `
 
 `docker compose up -d`
 


### PR DESCRIPTION
変更点は色々あるが、以下の２点を特に取り上げる

GitHub actionsでdocker imageをビルドする際の記載を追加した
特に、データベース関連の設定をシークレットで受け取って、イメージ内で取得できるように設定するのが大変だった

main.goファイルでは、if文で記載していた部分をswitch文で書き換えて記載した
これによって、視認性の向上が認められる
また、今回一番最初に行っていた環境変数の読み込みタイミングを、廃止した

今後は、グローバル環境変数の定義を初期化のタイミングで行い使い回せるようにしたい。
出なければ、どこでどの環境変数が使用かつ、初期化されているのか補足できないため
